### PR TITLE
Update various tofu modules to improve configurability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ tofu/main/*/.terraform.lock.hcl
 tofu/main/*/terraform.tfstate
 tofu/main/*/terraform.tfstate.*
 tofu/main/*/config
+*.tfvars
 
 ./dartboard

--- a/darts/aws_full.yaml
+++ b/darts/aws_full.yaml
@@ -3,48 +3,69 @@
 # all available variables are represented in this file
 # commented out lines show defaults
 
-tofu_main_directory: ./tofu/main/aws
+tofu_main_directory: /home/ivln/workspace/work/RancherVCS/scalability-tests/tofu/main/aws
 #tofu_parallelism: 10
 tofu_variables:
-#  downstream_cluster_count: 0
-#  region: us-east-1
-#  availability_zone: us-east-1a
-#  ssh_public_key_path: ~/.ssh/id_ed25519.pub
-#  ssh_private_key_path: ~/.ssh/id_ed25519
-#  upstream_server_count: 1
-#  upstream_agent_count: 0
-#  upstream_reserve_node_for_monitoring: false
-#  upstream_distro_version: v1.26.9+k3s1
-#  upstream_public_ip: true
-#  upstream_instance_type: i3.large
-#  upstream_ami: ami-009fd8a4732ea789b # openSUSE-Leap-15-5-v20230608-hvm-ssd-x86_64
-#  downstream_server_count: 1
-#  downstream_agent_count: 0
-#  downstream_distro_version: v1.26.9+k3s1
-#  downstream_public_ip: false
-#  downstream_instance_type: t4g.large
-#  downstream_ami: ami-0e55a8b472a265e3f # openSUSE-Leap-15-5-v20230608-hvm-ssd-arm64
-#  deploy_tester_cluster: true
-#  tester_server_count: 1
-#  tester_agent_count: 0
-#  tester_distro_version: v1.26.9+k3s1
-#  tester_public_ip: false
-#  tester_instance_type: t3a.large
-#  tester_ami: ami-009fd8a4732ea789b # openSUSE-Leap-15-5-v20230608-hvm-ssd-x86_64
-#  project_name: st
-#  first_kubernetes_api_port: 7445
-#  first_app_http_port: 9080
-#  first_app_https_port: 9443
+  project_name: st
+  region: us-east-1
+  availability_zone: us-east-1a
+  aws_profile: rancher-eng
+  ssh_private_key_path: ~/.ssh/id_ed25519
+  ssh_public_key_path: ~/.ssh/id_ed25519.pub
+  ssh_user: root
+  ssh_bastion_user: root
+  bastion_host_ami: ami-0e55a8b472a265e3f # openSUSE-Leap-15-5-v20230608-hvm-ssd-arm64
+
+  upstream_cluster:
+    name_prefix: upstream
+    server_count: 1
+    agent_count: 0
+    distro_version: v1.26.9+k3s1
+    public_ip: true
+    reserve_node_for_monitoring: false
+    # aws-specific
+    instance_type: i3.large
+    instance_tags: { Owner: st, DoNotDelete: true }
+    ami: ami-009fd8a4732ea789b # openSUSE-Leap-15-5-v20230608-hvm-ssd-x86_64
+
+  deploy_tester_cluster: true
+  tester_cluster:
+    name_prefix: tester
+    server_count: 1
+    agent_count: 0
+    distro_version: v1.26.9+k3s1
+    public_ip: true
+    reserve_node_for_monitoring: false
+    # aws-specific
+    instance_type: t3a.large
+    instance_tags: { Owner: st, DoNotDelete: true }
+    ami: ami-009fd8a4732ea789b # openSUSE-Leap-15-5-v20230608-hvm-ssd-x86_64
+
+  downstream_cluster_templates:
+    - cluster_count: 0 # defaults to 0 to keep in-line with previous behavior
+      name_prefix: first
+      server_count: 1
+      agent_count: 0
+      distro_version: v1.26.9+k3s1
+      public_ip: false
+      reserve_node_for_monitoring: false
+      # aws-specific
+      instance_type: t4g.large
+      instance_tags: { Owner: st, DoNotDelete: true }
+      ami: ami-0e55a8b472a265e3f # openSUSE-Leap-15-5-v20230608-hvm-ssd-arm64
+  first_kubernetes_api_port: 7445
+  first_app_http_port: 9080
+  first_app_https_port: 9443
 
 chart_variables:
   rancher_replicas: 3
   downstream_rancher_monitoring: true
-#  admin_password: adminadminadmin
+  #  admin_password: adminadminadmin
   rancher_version: 2.8.6
-#  rancher_image_override: rancher/rancher
-#  rancher_image_tag_override: v2.8.6-debug-1
-#  force_prime_registry: false
-# see https://github.com/rancher/charts/tree/release-v2.8/assets/rancher-monitoring-crd
+  #  rancher_image_override: rancher/rancher
+  #  rancher_image_tag_override: v2.8.6-debug-1
+  #  force_prime_registry: false
+  # see https://github.com/rancher/charts/tree/release-v2.8/assets/rancher-monitoring-crd
   rancher_monitoring_version: 103.1.1+up45.31.1
 #  cert_manager_version: 1.8.0
 #  tester_grafana_version: 6.56.5

--- a/tofu/main/aws/locals.tf
+++ b/tofu/main/aws/locals.tf
@@ -1,6 +1,10 @@
 locals {
+  downstream_clusters = [
+    for i, config in var.downstream_clusters : [
+      for c in range(config.quantity) : merge(config,{name_prefix = "${config.name_prefix}${i}-${c}"})
+    ]]
   all_clusters = flatten(concat([var.upstream_cluster],
-    var.downstream_clusters,
+    local.downstream_clusters,
     var.deploy_tester_cluster ? [var.tester_cluster] : []
   ))
 

--- a/tofu/main/aws/locals.tf
+++ b/tofu/main/aws/locals.tf
@@ -1,7 +1,7 @@
 locals {
   downstream_clusters = [
-    for i, config in var.downstream_clusters : [
-      for c in range(config.quantity) : merge(config,{name_prefix = "${config.name_prefix}${i}-${c}"})
+    for i, template in var.downstream_cluster_templates : [
+      for j in range(template.cluster_count) : merge(template,{name_prefix = "${template.name_prefix}${i}-${j}"})
     ]]
   all_clusters = flatten(concat([var.upstream_cluster],
     local.downstream_clusters,

--- a/tofu/main/aws/locals.tf
+++ b/tofu/main/aws/locals.tf
@@ -1,36 +1,8 @@
 locals {
-  all_clusters = concat([{
-    name                        = "upstream"
-    server_count                = var.upstream_server_count
-    agent_count                 = var.upstream_agent_count
-    distro_version              = var.upstream_distro_version
-    reserve_node_for_monitoring = var.upstream_reserve_node_for_monitoring
-    public_ip     = var.upstream_public_ip
-    instance_type = var.upstream_instance_type
-    ami           = var.upstream_ami
-  }],
-    [for i in range(var.downstream_cluster_count) :
-      {
-        name                        = "downstream-${i}"
-        server_count                = var.downstream_server_count
-        agent_count                 = var.downstream_agent_count
-        distro_version              = var.downstream_distro_version
-        reserve_node_for_monitoring = false
-        public_ip     = var.downstream_public_ip
-        instance_type = var.downstream_instance_type
-        ami           = var.downstream_ami
-      }],
-      var.deploy_tester_cluster ? [{
-      name                        = "tester"
-      server_count                = var.tester_server_count
-      agent_count                 = var.tester_agent_count
-      distro_version              = var.tester_distro_version
-      reserve_node_for_monitoring = false
-      public_ip     = var.tester_public_ip
-      instance_type = var.tester_instance_type
-      ami           = var.tester_ami
-    }] : []
-  )
+  all_clusters = flatten(concat([var.upstream_cluster],
+    var.downstream_clusters,
+    var.deploy_tester_cluster ? [var.tester_cluster] : []
+  ))
 
   k3s_clusters  = [for cluster in local.all_clusters : cluster if strcontains(cluster.distro_version, "k3s")]
   rke2_clusters = [for cluster in local.all_clusters : cluster if strcontains(cluster.distro_version, "rke2")]

--- a/tofu/main/aws/main.tf
+++ b/tofu/main/aws/main.tf
@@ -1,5 +1,7 @@
 provider "aws" {
   region = var.region
+  profile =  length(var.aws_profile) > 0 ? var.aws_profile : null
+
 }
 
 module "network" {
@@ -7,6 +9,8 @@ module "network" {
   project_name         = var.project_name
   region               = var.region
   availability_zone    = var.availability_zone
+  bastion_host_ami     = length(var.bastion_host_ami) > 0 ? var.bastion_host_ami : null
+  ssh_user             = var.ssh_user
   ssh_public_key_path  = var.ssh_public_key_path
   ssh_private_key_path = var.ssh_private_key_path
 }
@@ -15,7 +19,7 @@ module "k3s_cluster" {
   count        = length(local.k3s_clusters)
   source       = "../../modules/aws_k3s"
   project_name = var.project_name
-  name         = local.k3s_clusters[count.index].name
+  name         = local.k3s_clusters[count.index].name_prefix
   server_count = local.k3s_clusters[count.index].server_count
   agent_count  = local.k3s_clusters[count.index].agent_count
   agent_labels = local.k3s_clusters[count.index].reserve_node_for_monitoring ? [
@@ -26,7 +30,7 @@ module "k3s_cluster" {
   ] : []
   distro_version = local.k3s_clusters[count.index].distro_version
 
-  sans                      = ["${local.k3s_clusters[count.index].name}.local.gd"]
+  sans                      = ["${local.k3s_clusters[count.index].name_prefix}.local.gd"]
   local_kubernetes_api_port = var.first_kubernetes_api_port + count.index
   tunnel_app_http_port      = var.first_app_http_port + count.index
   tunnel_app_https_port     = var.first_app_https_port + count.index
@@ -35,7 +39,9 @@ module "k3s_cluster" {
   availability_zone         = var.availability_zone
   ssh_key_name              = module.network.key_name
   ssh_private_key_path      = var.ssh_private_key_path
+  ssh_user                  = var.ssh_user
   ssh_bastion_host          = module.network.bastion_public_name
+  ssh_bastion_user          = var.ssh_bastion_user
   subnet_id                 = local.k3s_clusters[count.index].public_ip ? module.network.public_subnet_id : module.network.private_subnet_id
   vpc_security_group_id     = local.k3s_clusters[count.index].public_ip ? module.network.public_security_group_id : module.network.private_security_group_id
 }
@@ -44,7 +50,7 @@ module "rke2_cluster" {
   count        = length(local.rke2_clusters)
   source       = "../../modules/aws_rke2"
   project_name = var.project_name
-  name         = local.rke2_clusters[count.index].name
+  name         = local.rke2_clusters[count.index].name_prefix
   server_count = local.rke2_clusters[count.index].server_count
   agent_count  = local.rke2_clusters[count.index].agent_count
   agent_labels = local.rke2_clusters[count.index].reserve_node_for_monitoring ? [
@@ -55,7 +61,7 @@ module "rke2_cluster" {
   ] : []
   distro_version = local.rke2_clusters[count.index].distro_version
 
-  sans                      = ["${local.rke2_clusters[count.index].name}.local.gd"]
+  sans                      = ["${local.rke2_clusters[count.index].name_prefix}.local.gd"]
   local_kubernetes_api_port = var.first_kubernetes_api_port + length(local.k3s_clusters) + count.index
   tunnel_app_http_port      = var.first_app_http_port + length(local.k3s_clusters) + count.index
   tunnel_app_https_port     = var.first_app_https_port + length(local.k3s_clusters) + count.index
@@ -64,7 +70,9 @@ module "rke2_cluster" {
   availability_zone         = var.availability_zone
   ssh_key_name              = module.network.key_name
   ssh_private_key_path      = var.ssh_private_key_path
+  ssh_user                  = var.ssh_user
   ssh_bastion_host          = module.network.bastion_public_name
+  ssh_bastion_user          = var.ssh_bastion_user
   subnet_id                 = local.rke2_clusters[count.index].public_ip ? module.network.public_subnet_id : module.network.private_subnet_id
   vpc_security_group_id     = local.rke2_clusters[count.index].public_ip ? module.network.public_security_group_id : module.network.private_security_group_id
 }

--- a/tofu/main/aws/outputs.tf
+++ b/tofu/main/aws/outputs.tf
@@ -1,5 +1,5 @@
 locals {
-  k3s_outputs = { for i, cluster in local.k3s_clusters : cluster.name => {
+  k3s_outputs = { for i, cluster in local.k3s_clusters : cluster.name_prefix => {
     kubeconfig = module.k3s_cluster[i].kubeconfig
     context    = module.k3s_cluster[i].context
 
@@ -19,7 +19,7 @@ locals {
         https_port = 443
       }
       tunnel = { // resolvable from the host running OpenTofu
-        name       = "${cluster.name}.local.gd"
+        name       = "${cluster.name_prefix}.local.gd"
         http_port  = module.k3s_cluster[i].tunnel_app_http_port
         https_port = module.k3s_cluster[i].tunnel_app_https_port
       }
@@ -49,7 +49,7 @@ locals {
         https_port = 443
       }
       tunnel = { // resolvable from the host running OpenTofu
-        name       = "${cluster.name}.local.gd"
+        name       = "${cluster.name_prefix}.local.gd"
         http_port  = module.rke2_cluster[i].tunnel_app_http_port
         https_port = module.rke2_cluster[i].tunnel_app_https_port
       }

--- a/tofu/main/aws/terraform.tf
+++ b/tofu/main/aws/terraform.tf
@@ -15,7 +15,7 @@ terraform {
     }
     ssh = {
       source  = "loafoe/ssh"
-      version = "2.2.1"
+      version = "2.7.0"
     }
   }
 }

--- a/tofu/main/aws/variables.tf
+++ b/tofu/main/aws/variables.tf
@@ -1,18 +1,24 @@
 # Frequently changed variables
 
-variable "downstream_cluster_count" {
-  description = "Number of downstream clusters"
-  default     = 0
-}
-
 variable "region" {
   description = "AWS region for this deployment"
   default     = "us-east-1"
 }
 
+variable "aws_profile" {
+  description = "Local ~/.aws/config profile to utilize for AWS access"
+  default = ""
+}
+
 variable "availability_zone" {
   description = "AWS availability zone for this deployment"
   default     = "us-east-1a"
+}
+
+variable "bastion_host_ami" {
+  description = "AMI ID"
+  default     = "ami-0e55a8b472a265e3f"
+  // openSUSE-Leap-15-5-v20230608-hvm-ssd-arm64-a516e959-df54-4035-bb1a-63599b7a6df9
 }
 
 variable "ssh_public_key_path" {
@@ -25,114 +31,131 @@ variable "ssh_private_key_path" {
   default     = "~/.ssh/id_ed25519"
 }
 
+variable "ssh_user" {
+  description = "User name to use for the SSH connection"
+  type        = string
+  default     = "root"
+}
+
+variable "ssh_bastion_user" {
+  description = "User name for the SSH bastion host's OS"
+  default     = "root"
+}
+
 # Upstream cluster specifics
+variable "upstream_cluster" {
+  type = object({
+    name_prefix    = string // Prefix to append to objects created for this cluster
+    server_count   = number // Number of server nodes in the upstream cluster
+    agent_count    = number // Number of agent nodes in the upstream cluster
+    distro_version = string // Version of the Kubernetes distro in the upstream cluster
 
-variable "upstream_server_count" {
-  description = "Number of server nodes in the upstream cluster"
-  default     = 1
-}
+    public_ip = bool // Whether the upstream cluster should have a public IP assigned
+    reserve_node_for_monitoring = bool // Set a 'monitoring' label and taint on one node of the upstream cluster to reserve it for monitoring
 
-variable "upstream_agent_count" {
-  description = "Number of agent nodes in the upstream cluster"
-  default     = 0
-}
+    // aws-specific
+    datastore     = optional(string) // Optional datastore to utilize for the upstream cluster
+    instance_type = string // Instance type for the upstream cluster nodes
+    instance_tags = map(string) // tags to apply to the EC2 instances
+    ami           = string // AMI for upstream cluster nodes
+  })
+  default = {
+    name_prefix    = "upstream"
+    server_count   = 1
+    agent_count    = 0
+    distro_version = "v1.26.9+k3s1"
+    public_ip = true
+    reserve_node_for_monitoring = false
 
-variable "upstream_reserve_node_for_monitoring" {
-  description = "Set a 'monitoring' label and taint on one node of the upstream cluster to reserve it for monitoring"
-  default = false
-}
-
-variable "upstream_distro_version" {
-  description = "Version of the Kubernetes distro in the upstream cluster"
-  default     = "v1.26.9+k3s1"
-}
-
-variable "upstream_public_ip" {
-  description = "Whether the upstream cluster should have a public IP assigned"
-  default = true
-}
-
-variable "upstream_instance_type" {
-  description = "Instance type for the upstream cluster nodes"
-  default = "i3.large"
-}
-
-variable "upstream_ami" {
-  description = "AMI for upstream cluster nodes"
-  default = "ami-009fd8a4732ea789b" // openSUSE-Leap-15-5-v20230608-hvm-ssd-x86_64
+    // aws-specific
+    instance_type = "i3.large"
+    instance_tags = {
+      "Owner": "st",
+      "DoNotDelete": "true"
+    }
+    ami           = "ami-009fd8a4732ea789b" // openSUSE-Leap-15-5-v20230608-hvm-ssd-x86_64
+  }
 }
 
 
 # Downstream cluster specifics
 
-variable "downstream_server_count" {
-  description = "Number of server nodes in each downstream cluster"
-  default     = 1
-}
+variable "downstream_clusters" {
+  type = list(object({
+    quantity       = number // Number of downstream clusters that should be created using this configuration
+    name_prefix    = string // Prefix to append to objects created for this cluster
+    server_count   = number // Number of server nodes in the downstream cluster
+    agent_count    = number // Number of agent nodes in the downstream cluster
+    distro_version = string // Version of the Kubernetes distro in the downstream cluster
 
-variable "downstream_agent_count" {
-  description = "Number of agent nodes in the downstream cluster"
-  default     = 0
-}
+    public_ip = bool // Whether the downstream cluster should have a public IP assigned
+    reserve_node_for_monitoring = bool // Set a 'monitoring' label and taint on one node of the downstream cluster to reserve it for monitoring
 
-variable "downstream_distro_version" {
-  description = "Version of the Kubernetes distro in the downstream clusters"
-  default     = "v1.26.9+k3s1"
-}
+    // aws-specific
+    datastore     = optional(string) // Optional datastore to utilize for the downstream cluster
+    instance_type = string // Instance type for the downstream cluster nodes
+    instance_tags = map(string) // tags to apply to the EC2 instances
+    ami           = string // AMI for downstream cluster nodes
+  }))
+  default = [{
+    quantity       = 0 // defaults to 0 to keep in-line with previous behavior
+    name_prefix    = "downstream"
+    server_count   = 1
+    agent_count    = 0
+    distro_version = "v1.26.9+k3s1"
+    public_ip = false
+    reserve_node_for_monitoring = false
 
-variable "downstream_public_ip" {
-  description = "Whether the downstream cluster should have a public IP assigned"
-  default = false
+    // aws-specific
+    instance_type = "t4g.large"
+    instance_tags = {
+      "Owner": "st",
+      "DoNotDelete": "true"
+    }
+    ami           = "ami-0e55a8b472a265e3f" // openSUSE-Leap-15-5-v20230608-hvm-ssd-arm64
+  }]
 }
-
-variable "downstream_instance_type" {
-  description = "Instance type for the downstream cluster nodes"
-  default = "t4g.large"
-}
-
-variable "downstream_ami" {
-  description = "AMI for downstream cluster nodes"
-  default = "ami-0e55a8b472a265e3f" // openSUSE-Leap-15-5-v20230608-hvm-ssd-arm64
-}
-
 
 # Tester cluster specifics
+
+variable "tester_cluster" {
+  type = object({
+    name_prefix    = string // Prefix to append to objects created for this cluster
+    server_count   = number // Number of server nodes in the tester cluster
+    agent_count    = number // Number of agent nodes in the tester cluster
+    distro_version = string // Version of the Kubernetes distro in the tester cluster
+
+    public_ip = bool // Whether the tester cluster should have a public IP assigned
+    reserve_node_for_monitoring = bool // Set a 'monitoring' label and taint on one node of the tester cluster to reserve it for monitoring
+
+    // aws-specific
+    datastore     = optional(string) // Optional datastore to utilize for the tester cluster
+    instance_type = string // Instance type for the tester cluster nodes
+    instance_tags = map(string) // tags to apply to the EC2 instances
+    ami           = string // AMI for tester cluster nodes
+  })
+  default = {
+    name_prefix    = "tester"
+    server_count   = 1
+    agent_count    = 0
+    distro_version = "v1.26.9+k3s1"
+    public_ip = true
+    reserve_node_for_monitoring = false
+
+    // aws-specific
+    instance_type = "t3a.large"
+    instance_tags = {
+      "Owner": "st",
+      "DoNotDelete": "true"
+    }
+    ami           = "ami-009fd8a4732ea789b" // openSUSE-Leap-15-5-v20230608-hvm-ssd-x86_64
+  }
+}
 
 variable "deploy_tester_cluster" {
   description = "Use false not to deploy a tester cluster"
   default     = true
 }
-
-variable "tester_server_count" {
-  description = "Number of server nodes in each tester cluster"
-  default     = 1
-}
-
-variable "tester_agent_count" {
-  description = "Number of agent nodes in the tester cluster"
-  default     = 0
-}
-
-variable "tester_distro_version" {
-  description = "Version of the Kubernetes distro in the tester clusters"
-  default     = "v1.26.9+k3s1"
-}
-
-variable "tester_public_ip" {
-  description = "Whether the tester cluster should have a public IP assigned"
-  default = true
-}
-
-variable "tester_instance_type" {
-  description = "Instance type for the tester cluster nodes"
-  default = "t3a.large"
-}
-
-variable "tester_ami" {
-  description = "AMI for tester cluster nodes"
-  default = "ami-009fd8a4732ea789b" // openSUSE-Leap-15-5-v20230608-hvm-ssd-x86_64
-}
-
 
 # "Multi-tenancy" variables
 

--- a/tofu/main/aws/variables.tf
+++ b/tofu/main/aws/variables.tf
@@ -1,5 +1,4 @@
 # Frequently changed variables
-
 variable "region" {
   description = "AWS region for this deployment"
   default     = "us-east-1"
@@ -77,12 +76,10 @@ variable "upstream_cluster" {
   }
 }
 
-
 # Downstream cluster specifics
-
-variable "downstream_clusters" {
+variable "downstream_cluster_templates" {
   type = list(object({
-    quantity       = number // Number of downstream clusters that should be created using this configuration
+    cluster_count       = number // Number of downstream clusters that should be created using this configuration
     name_prefix    = string // Prefix to append to objects created for this cluster
     server_count   = number // Number of server nodes in the downstream cluster
     agent_count    = number // Number of agent nodes in the downstream cluster
@@ -98,7 +95,7 @@ variable "downstream_clusters" {
     ami           = string // AMI for downstream cluster nodes
   }))
   default = [{
-    quantity       = 0 // defaults to 0 to keep in-line with previous behavior
+    cluster_count       = 0 // defaults to 0 to keep in-line with previous behavior
     name_prefix    = "downstream"
     server_count   = 1
     agent_count    = 0
@@ -117,7 +114,6 @@ variable "downstream_clusters" {
 }
 
 # Tester cluster specifics
-
 variable "tester_cluster" {
   type = object({
     name_prefix    = string // Prefix to append to objects created for this cluster
@@ -158,7 +154,6 @@ variable "deploy_tester_cluster" {
 }
 
 # "Multi-tenancy" variables
-
 variable "project_name" {
   description = "Name of this project, used as prefix for resources it creates"
   default     = "st"

--- a/tofu/modules/aws_etcd/inputs.tf
+++ b/tofu/modules/aws_etcd/inputs.tf
@@ -39,10 +39,21 @@ variable "ssh_private_key_path" {
   type        = string
 }
 
+variable "ssh_user" {
+  description = "User name to use for the SSH connection"
+  type        = string
+  default     = "root"
+}
+
 variable "ssh_bastion_host" {
-  description = "Public name of the SSH bastion host. Leave null for publicly accessible nodes"
+  description = "Public name of the SSH bastion host. Leave null for publicly accessible instances"
   type        = string
   default     = null
+}
+
+variable "ssh_bastion_user" {
+  description = "User name for the SSH bastion host's OS"
+  default     = "root"
 }
 
 variable "subnet_id" {

--- a/tofu/modules/aws_etcd/main.tf
+++ b/tofu/modules/aws_etcd/main.tf
@@ -8,9 +8,11 @@ module "server_nodes" {
   name                  = "${var.name}-node-${count.index}"
   ssh_key_name          = var.ssh_key_name
   ssh_private_key_path  = var.ssh_private_key_path
+  ssh_user              = var.ssh_user
   subnet_id             = var.subnet_id
   vpc_security_group_id = var.vpc_security_group_id
   ssh_bastion_host      = var.ssh_bastion_host
+  ssh_bastion_user      = var.ssh_bastion_user
   ssh_tunnels           = count.index == 0 ? var.additional_ssh_tunnels : []
 }
 

--- a/tofu/modules/aws_host/inputs.tf
+++ b/tofu/modules/aws_host/inputs.tf
@@ -34,10 +34,21 @@ variable "ssh_private_key_path" {
   type        = string
 }
 
+variable "ssh_user" {
+  description = "User name to use for the SSH connection"
+  type        = string
+  default     = "root"
+}
+
 variable "ssh_bastion_host" {
   description = "Public name of the SSH bastion host. Leave null for publicly accessible instances"
   type        = string
   default     = null
+}
+
+variable "ssh_bastion_user" {
+  description = "User name for the SSH bastion host's OS"
+  default     = "root"
 }
 
 variable "ssh_tunnels" {

--- a/tofu/modules/aws_host/user_data.yaml
+++ b/tofu/modules/aws_host/user_data.yaml
@@ -5,4 +5,4 @@ ssh_pwauth: true
 chpasswd:
   expire: false
   list: |
-    root:linux
+    ${ssh_user}:linux

--- a/tofu/modules/aws_k3s/inputs.tf
+++ b/tofu/modules/aws_k3s/inputs.tf
@@ -55,10 +55,21 @@ variable "ssh_private_key_path" {
   type        = string
 }
 
+variable "ssh_user" {
+  description = "User name to use for the SSH connection"
+  type        = string
+  default     = "root"
+}
+
 variable "ssh_bastion_host" {
-  description = "Public name of the SSH bastion host. Leave null for publicly accessible nodes"
+  description = "Public name of the SSH bastion host. Leave null for publicly accessible instances"
   type        = string
   default     = null
+}
+
+variable "ssh_bastion_user" {
+  description = "User name for the SSH bastion host's OS"
+  default     = "root"
 }
 
 variable "subnet_id" {

--- a/tofu/modules/aws_k3s/main.tf
+++ b/tofu/modules/aws_k3s/main.tf
@@ -8,9 +8,11 @@ module "server_nodes" {
   name                  = "${var.name}-server-${count.index}"
   ssh_key_name          = var.ssh_key_name
   ssh_private_key_path  = var.ssh_private_key_path
+  ssh_user              = var.ssh_user
   subnet_id             = var.subnet_id
   vpc_security_group_id = var.vpc_security_group_id
   ssh_bastion_host      = var.ssh_bastion_host
+  ssh_bastion_user      = var.ssh_bastion_user
   ssh_tunnels = count.index == 0 ? [
     [var.local_kubernetes_api_port, 6443],
     [var.tunnel_app_http_port, 80],
@@ -29,9 +31,11 @@ module "agent_nodes" {
   name                        = "${var.name}-agent-${count.index}"
   ssh_key_name                = var.ssh_key_name
   ssh_private_key_path        = var.ssh_private_key_path
+  ssh_user                    = var.ssh_user
   subnet_id                   = var.subnet_id
   vpc_security_group_id       = var.vpc_security_group_id
   ssh_bastion_host            = var.ssh_bastion_host
+  ssh_bastion_user            = var.ssh_bastion_user
   host_configuration_commands = var.host_configuration_commands
 }
 
@@ -58,7 +62,9 @@ module "k3s" {
   sans         = compact(concat(var.sans, var.server_count > 0 ? [module.server_nodes[0].private_name, module.server_nodes[0].public_name] : []))
 
   ssh_private_key_path      = var.ssh_private_key_path
+  ssh_user                  = var.ssh_user
   ssh_bastion_host          = var.ssh_bastion_host
+  ssh_bastion_user          = var.ssh_bastion_user
   local_kubernetes_api_port = var.local_kubernetes_api_port
 
   distro_version      = var.distro_version

--- a/tofu/modules/aws_network/inputs.tf
+++ b/tofu/modules/aws_network/inputs.tf
@@ -29,6 +29,18 @@ variable "ssh_private_key_path" {
   type        = string
 }
 
+variable "ssh_user" {
+  description = "User name to use for the SSH connection"
+  type        = string
+  default     = "root"
+}
+
+variable "ssh_bastion_host" {
+  description = "Public name of the SSH bastion host. Leave null for publicly accessible instances"
+  type        = string
+  default     = null
+}
+
 variable "bastion_host_ami" {
   description = "AMI ID"
   default     = "ami-0e55a8b472a265e3f"

--- a/tofu/modules/aws_network/main.tf
+++ b/tofu/modules/aws_network/main.tf
@@ -241,6 +241,7 @@ module "bastion" {
   instance_type         = var.bastion_host_instance_type
   ssh_key_name          = aws_key_pair.key_pair.key_name
   ssh_private_key_path  = var.ssh_private_key_path
+  ssh_user              = var.ssh_user
   subnet_id             = aws_subnet.public.id
   vpc_security_group_id = aws_security_group.public.id
 }

--- a/tofu/modules/aws_postgres_kine/inputs.tf
+++ b/tofu/modules/aws_postgres_kine/inputs.tf
@@ -15,7 +15,7 @@ variable "availability_zone" {
 
 variable "ami" {
   description = "AMI ID for all nodes in this cluster"
-  default     = "ami-01b5ec3ed8678d8b7" // Amazon Linux 2 LTS Arm64 Kernel 5.10 AMI 2.0.20221103.3 arm64 HVM gp2
+  default     = "ami-0728ec0041b1d38ac" // Amazon Linux 2 LTS Arm64 Kernel 5.10 AMI 2.0.20221103.3 arm64 HVM gp2
 }
 
 variable "instance_type" {

--- a/tofu/modules/aws_rke2/inputs.tf
+++ b/tofu/modules/aws_rke2/inputs.tf
@@ -55,10 +55,21 @@ variable "ssh_private_key_path" {
   type        = string
 }
 
+variable "ssh_user" {
+  description = "User name to use for the SSH connection"
+  type        = string
+  default     = "root"
+}
+
 variable "ssh_bastion_host" {
-  description = "Public name of the SSH bastion host. Leave null for publicly accessible nodes"
+  description = "Public name of the SSH bastion host. Leave null for publicly accessible instances"
   type        = string
   default     = null
+}
+
+variable "ssh_bastion_user" {
+  description = "User name for the SSH bastion host's OS"
+  default     = "root"
 }
 
 variable "subnet_id" {

--- a/tofu/modules/aws_rke2/main.tf
+++ b/tofu/modules/aws_rke2/main.tf
@@ -8,9 +8,11 @@ module "server_nodes" {
   name                  = "${var.name}-server-${count.index}"
   ssh_key_name          = var.ssh_key_name
   ssh_private_key_path  = var.ssh_private_key_path
+  ssh_user              = var.ssh_user
+  ssh_bastion_host      = var.ssh_bastion_host
+  ssh_bastion_user      = var.ssh_bastion_user
   subnet_id             = var.subnet_id
   vpc_security_group_id = var.vpc_security_group_id
-  ssh_bastion_host      = var.ssh_bastion_host
   ssh_tunnels = count.index == 0 ? [
     [var.local_kubernetes_api_port, 6443],
     [var.tunnel_app_http_port, 80],
@@ -29,9 +31,11 @@ module "agent_nodes" {
   name                        = "${var.name}-agent-${count.index}"
   ssh_key_name                = var.ssh_key_name
   ssh_private_key_path        = var.ssh_private_key_path
+  ssh_user                    = var.ssh_user
+  ssh_bastion_host            = var.ssh_bastion_host
+  ssh_bastion_user            = var.ssh_bastion_user
   subnet_id                   = var.subnet_id
   vpc_security_group_id       = var.vpc_security_group_id
-  ssh_bastion_host            = var.ssh_bastion_host
   host_configuration_commands = var.host_configuration_commands
 }
 
@@ -46,7 +50,9 @@ module "rke2" {
   sans         = var.sans
 
   ssh_private_key_path      = var.ssh_private_key_path
+  ssh_user                  = var.ssh_user
   ssh_bastion_host          = var.ssh_bastion_host
+  ssh_bastion_user          = var.ssh_bastion_user
   local_kubernetes_api_port = var.local_kubernetes_api_port
 
   distro_version      = var.distro_version

--- a/tofu/modules/k3s/inputs.tf
+++ b/tofu/modules/k3s/inputs.tf
@@ -42,21 +42,28 @@ variable "sans" {
   default     = []
 }
 
-variable "ssh_user" {
-  description = "User name for SSH access"
-  default     = "root"
-}
-
 variable "ssh_private_key_path" {
   description = "Path of private ssh key used to access the instance"
   type        = string
   default     = null
 }
 
+variable "ssh_user" {
+  description = "User name to use for the host SSH connection"
+  type        = string
+  default     = "root"
+}
+
 variable "ssh_bastion_host" {
   description = "Public name of the SSH bastion host. Leave null for publicly accessible instances"
   type        = string
   default     = null
+}
+
+variable "ssh_bastion_user" {
+  description = "User name for the SSH connection to the bastion"
+  type        = string
+  default     = "root"
 }
 
 variable "local_kubernetes_api_port" {

--- a/tofu/modules/k3s/main.tf
+++ b/tofu/modules/k3s/main.tf
@@ -12,6 +12,7 @@ resource "ssh_sensitive_resource" "first_server_installation" {
   private_key  = file(var.ssh_private_key_path)
   user         = var.ssh_user
   bastion_host = var.ssh_bastion_host
+  bastion_user = var.ssh_bastion_user
   timeout      = "600s"
 
   file {
@@ -61,6 +62,7 @@ resource "ssh_resource" "additional_server_installation" {
   private_key  = file(var.ssh_private_key_path)
   user         = var.ssh_user
   bastion_host = var.ssh_bastion_host
+  bastion_user = var.ssh_bastion_user
   timeout      = "600s"
 
   file {
@@ -102,6 +104,7 @@ resource "ssh_resource" "agent_installation" {
   private_key  = file(var.ssh_private_key_path)
   user         = var.ssh_user
   bastion_host = var.ssh_bastion_host
+  bastion_user = var.ssh_bastion_user
   timeout      = "600s"
 
   file {

--- a/tofu/modules/rke2/inputs.tf
+++ b/tofu/modules/rke2/inputs.tf
@@ -42,19 +42,26 @@ variable "sans" {
   default     = []
 }
 
-variable "ssh_user" {
-  description = "User name for SSH access"
-  default     = "root"
-}
-
 variable "ssh_private_key_path" {
   description = "Path of private ssh key used to access the instance"
   type        = string
 }
 
+variable "ssh_user" {
+  description = "User name to use for the SSH connection"
+  type        = string
+  default     = "root"
+}
+
 variable "ssh_bastion_host" {
   description = "Public name of the SSH bastion host. Leave null for publicly accessible instances"
+  type        = string
   default     = null
+}
+
+variable "ssh_bastion_user" {
+  description = "User name for the SSH bastion host's OS"
+  default     = "root"
 }
 
 variable "local_kubernetes_api_port" {

--- a/tofu/modules/rke2/main.tf
+++ b/tofu/modules/rke2/main.tf
@@ -12,6 +12,7 @@ resource "ssh_sensitive_resource" "first_server_installation" {
   private_key  = file(var.ssh_private_key_path)
   user         = var.ssh_user
   bastion_host = var.ssh_bastion_host
+  bastion_user = var.ssh_bastion_user
   timeout      = "600s"
 
   file {
@@ -59,6 +60,7 @@ resource "ssh_resource" "additional_server_installation" {
   private_key  = file(var.ssh_private_key_path)
   user         = var.ssh_user
   bastion_host = var.ssh_bastion_host
+  bastion_user = var.ssh_bastion_user
   timeout      = "600s"
 
   file {
@@ -98,6 +100,7 @@ resource "ssh_resource" "agent_installation" {
   private_key  = file(var.ssh_private_key_path)
   user         = var.ssh_user
   bastion_host = var.ssh_bastion_host
+  bastion_user = var.ssh_bastion_user
   timeout      = "600s"
 
   file {

--- a/tofu/modules/ssh_access/input.tf
+++ b/tofu/modules/ssh_access/input.tf
@@ -14,20 +14,27 @@ variable "public_name" {
   default     = null
 }
 
-variable "ssh_user" {
-  description = "User name used for SSH access in the host and the bastion"
-  default     = "root"
-}
-
 variable "ssh_private_key_path" {
   description = "Path of private SSH key for the host and the bastion"
   type        = string
 }
 
+variable "ssh_user" {
+  description = "User name to use for the host SSH connection"
+  type        = string
+  default     = "root"
+}
+
 variable "ssh_bastion_host" {
-  description = "Public name of the SSH bastion host (if any)"
+  description = "Public name of the SSH bastion host. Leave null for publicly accessible instances"
   type        = string
   default     = null
+}
+
+variable "ssh_bastion_user" {
+  description = "User name for the SSH connection to the bastion"
+  type        = string
+  default     = "root"
 }
 
 variable "ssh_tunnels" {

--- a/tofu/modules/ssh_access/main.tf
+++ b/tofu/modules/ssh_access/main.tf
@@ -18,6 +18,7 @@ resource "local_file" "open_tunnels" {
   count = length(var.ssh_tunnels) > 0 ? 1 : 0
   content = templatefile("${path.module}/open-tunnels-to.sh", {
     ssh_bastion_host     = var.ssh_bastion_host
+    ssh_bastion_user     = var.ssh_bastion_user
     ssh_tunnels          = var.ssh_tunnels
     private_name         = var.private_name
     public_name          = var.public_name

--- a/tofu/modules/ssh_access/open-tunnels-to.sh
+++ b/tofu/modules/ssh_access/open-tunnels-to.sh
@@ -11,7 +11,7 @@ nohup ssh -o IgnoreUnknown=TofuCreatedThisTunnel \
   -i ${ssh_private_key_path} \
   -N \
   %{ for tunnel in ssh_tunnels }-L ${tunnel[0]}:localhost:${tunnel[1]} %{ endfor }\
-  %{ if ssh_bastion_host != null ~}-o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${ssh_private_key_path} -W %h:%p ${ssh_user}@${ssh_bastion_host}"\%{ endif ~}
+  %{ if ssh_bastion_host != null ~}-o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${ssh_private_key_path} -W %h:%p ${ssh_bastion_user}@${ssh_bastion_host}"\%{ endif ~}
   ${ssh_user}@${ssh_bastion_host != null ? private_name : public_name} >/dev/null 2>&1 &
 
 %{ for tunnel in ssh_tunnels }


### PR DESCRIPTION
- Adds new inputs for specifying the ssh usernames for different OSes
- Consolidates cluster configuration inputs into 3 vars, 1 for each of upstream, downstream and tester clusters
- Adds an optional aws_profile var for easy usage of different credentials
- Adds additional bastion host-specific input vars